### PR TITLE
Lowercase 'p' in Create PropTypes snippet

### DIFF
--- a/snippets/snippets-react-native-javascript.json
+++ b/snippets/snippets-react-native-javascript.json
@@ -959,7 +959,7 @@
   "PropTypes": {
     "prefix": "pt",
     "body": [
-      "${1}.PropTypes = {",
+      "${1}.propTypes = {",
       "",
       "};"
     ],


### PR DESCRIPTION
As per issue: https://github.com/jundat95/react-native-snippet/issues/5