### PR TITLE
Change 'dob' Snippet

### DIFF
--- a/snippets/snippets-react-native-typescript.json
+++ b/snippets/snippets-react-native-typescript.json
@@ -928,7 +928,7 @@
   },
   "destructingObject": {
     "prefix": "dob",
-    "body": "const {${1:propertyName}} = ${2:objectToDestruct}",
+    "body": "const {${2:propertyName}} = ${1:objectToDestruct}",
     "description": "Creates and assigns a local variable using object destructing"
   },
   "destructingArray": {


### PR DESCRIPTION
In Typescript is better define first the object, because in this way we can use interfaces props to complete destruction more fast.